### PR TITLE
chore(claude): conform Claude configuration to workstation conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,29 @@
-# dependencies
+# Secrets
+**/.env*
+!**/.env.example
+
+# Dependencies
 .venv/
 
-# cache
+# Build Artifacts
+dist/
+*.egg-info/
+
+# Tooling
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/
 .ty/
 **/__pycache__/
 **/__marimo__/
-
-# package
-dist/
-*.egg-info/
-
-# claude
+**/.vscode/*
+!**/.vscode/extensions.json
 .claude/*
-!.claude/agents
-!.claude/references
-!.claude/rules
-!.claude/skills
+!.claude/agents/
+!.claude/references/
+!.claude/rules/
+!.claude/skills/
 !.claude/settings.json
+
+# Meta
+**/.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,17 +68,6 @@ topologyx/
 | `make uv-update`     | Update dependencies                     |
 | `make marimo`        | Launch Marimo notebook server           |
 
-## Code Conventions
-
-- Line length: 88 characters
-- Type hints required on all functions
-- Conventional commits enforced via pre-commit
-- Branch naming: `{initials}/{descriptive-kebab-case}`
-- Naming:
-  - `snake_case` for functions and variables
-  - `PascalCase` for classes
-  - `SCREAMING_SNAKE_CASE` for constants
-
 ## CI/CD
 
 - **Continuous Integration**: Runs on PR/merge_group


### PR DESCRIPTION
Drop the CLAUDE.md Code Conventions section (global rules a personal-tier repo inherits live), conform .gitignore (Secrets/.env handling, .vscode/* whitelist, blast-radius order), and untrack .vscode/settings.json.