### PR TITLE
docs(claude): refine the agentic layer for a public library

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,5 +40,8 @@ jobs:
       - name: Run Type Check
         run: make types
 
+      - name: Run Tests
+        run: make test
+
       - name: Validate Renovate Config
         run: npx --yes --package "renovate@${RENOVATE_VERSION}" renovate-config-validator --strict

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 *.egg-info/
 
 # Tooling
+.coverage
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,3 @@
 # AGENTS.md
 
-This repository is governed by `CLAUDE.md`. Read it first — it is the canonical source for stack, commands, conventions, layout, rules, references, and agents. This file is a compatibility pointer for Codex and Antigravity and never extends beyond `CLAUDE.md`.
+This repository is governed by `CLAUDE.md`. Read it first — it is the canonical source for stack, architecture, commands, gates, and release flow. This file is a compatibility pointer for Codex and Antigravity and never extends beyond `CLAUDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,55 +1,41 @@
 # TopologyX
 
-Topological Data Analysis (TDA) library for Python projects.
+Topological Data Analysis library — filtrations, persistence descriptors, ToMaTo clustering, and Keras layers built on persistence features. Published to PyPI as `topologyx`.
 
-## Tech Stack
+## Stack
 
-| Layer                | Technology     |
-| -------------------- | -------------- |
-| Language             | Python 3.13    |
-| Package Manager      | uv             |
-| Linting & Formatting | Ruff           |
-| Type Checking        | ty             |
-| Testing              | Pytest         |
-| CI/CD                | GitHub Actions |
+Python is pinned to `==3.13.*` — an exact pin, not a floor, so `uv sync` refuses any other interpreter. uv for packaging, Gudhi for simplicial complexes and persistence, scikit-learn for neighbours and decomposition, NumPy throughout, Keras for the channel layers, Matplotlib for the plotting helpers, Marimo for the examples.
 
-## Prerequisites
+`scipy.stats.gaussian_kde` is imported by `clustering/` but SciPy is not a declared dependency — it arrives transitively through scikit-learn. Treat that as a latent break, not a licence to add more undeclared imports.
 
-- Python 3.13
-- uv (Astral package manager)
+## Architecture
 
-## Quick Start
+Three subpackages under `src/topologyx/`, and the unusual part is that **each `__init__.py` holds the implementation**, not re-exports. The sibling modules beside it are helpers.
 
-```bash
-git clone https://github.com/merylldindin/topologyx
-cd topologyx
-make setup
+- `filtrations/` — `Filtration` (alpha complex, or a hand-built simplex tree for 1D/2D/3D input), `Levels` (upper and lower sublevel filtration of a series), `FiltrationType`. `utils.py` builds Betti curves, persistence landscapes and persistence images, and plots them.
+- `clustering/` — `TomatoClustering`, `ClusterGenerator`, `ClusterStructure`. `unionfind.py` is the weighted union-find with path compression that ToMaTo merges through; `utils.py` plots.
+- `channels/` — `betti_channel` and `silhouette_channel`, 1D convolutional Keras stacks consuming persistence descriptors, plus `SilhouetteLayer` in `silhouette.py`.
+
+Two constraints that shape the code:
+
+- **Gudhi ships no type stubs.** Every `gudhi.SimplexTree()` and `gudhi.AlphaComplex()` construction carries `# type: ignore`, and `SimplexTreeProtocol` in `filtrations/__init__.py` exists to give the returned object a typed interface. Extend that Protocol rather than widening a signature to `Any`.
+- **Importing `topologyx.channels` pulls Keras and a configured backend.** The other two subpackages do not, so keep Keras imports out of them.
+
+`Filtration` built with `use_alpha=False` handles 1D, 2D and 3D input only and raises `ValueError` beyond that; the alpha-complex path has no such ceiling.
+
+## Public API
+
+Semver tracks what the three subpackages export:
+
+```python
+from topologyx.filtrations import Filtration, FiltrationType, Levels
+from topologyx.clustering import ClusterGenerator, ClusterStructure, TomatoClustering
+from topologyx.channels import betti_channel, silhouette_channel
 ```
 
-## Project Structure
+Renaming or removing any of those, or changing a keyword argument on their public methods, is a breaking change.
 
-```
-topologyx/
-├── src/topologyx/           # Main package
-│   ├── main.py              # CLI entry point
-│   ├── channels/            # Signal processing channels
-│   │   ├── __init__.py
-│   │   └── silhouette.py
-│   ├── clustering/          # Clustering algorithms
-│   │   ├── __init__.py
-│   │   ├── unionfind.py
-│   │   └── utils.py
-│   └── filtrations/         # TDA filtrations
-│       ├── __init__.py
-│       └── utils.py
-├── examples/                # Marimo notebook examples
-│   ├── clustering.py
-│   └── filtrations.py
-├── pyproject.toml           # uv configuration
-├── .pre-commit-config.yaml
-├── Makefile
-└── renovate.json
-```
+The package is import-only in practice. `pyproject.toml` declares a `topologyx` console script pointing at `topologyx.main:cli`, but `src/topologyx/main.py` is empty, so the installed command fails — do not document or extend a CLI without implementing it first.
 
 ## Commands
 
@@ -57,40 +43,38 @@ topologyx/
 | -------------------- | --------------------------------------- |
 | `make setup`         | Install dependencies + pre-commit hooks |
 | `make setup-hard`    | Clean install from scratch              |
-| `make format`        | Check code formatting                   |
-| `make format-fix`    | Format code with Ruff                   |
-| `make lint`          | Lint code with Ruff                     |
-| `make lint-fix`      | Auto-fix linting issues                 |
+| `make format`        | Check formatting                        |
+| `make format-fix`    | Format with Ruff                        |
+| `make lint`          | Lint with Ruff                          |
+| `make lint-fix`      | Lint and auto-fix                       |
 | `make types`         | Type check with ty                      |
-| `make test`          | Run test suite                          |
-| `make test-coverage` | Run tests with coverage                 |
+| `make test`          | Run the test suite                      |
+| `make test-coverage` | Run tests with a coverage report        |
+| `make marimo`        | Open the examples in Marimo             |
 | `make uv-lock`       | Lock dependencies                       |
-| `make uv-update`     | Update dependencies                     |
-| `make marimo`        | Launch Marimo notebook server           |
+| `make uv-update`     | Upgrade the lockfile                    |
 
-## CI/CD
+There is no `check` aggregate. `make format lint types test` is the full local gate.
 
-- **Continuous Integration**: Runs on PR/merge_group
-  - Ruff format check
-  - Ruff lint
-  - ty type check
-- **PyPI Release**: Manual trigger with semantic version
+`examples/` holds Marimo notebooks, which are plain `.py` files and are linted and formatted like the rest of the source.
+
+## Gates
+
+`make setup` installs the pre-commit hooks. They run on every commit: trailing whitespace, end-of-file, YAML and TOML syntax, `ruff format`, `ruff check --fix`, and commitizen on the message — so every commit must be a Conventional Commit.
+
+CI runs on `pull_request` and `merge_group`, and runs the same four make targets.
+
+Two gates are weaker than they look:
+
+- **`make types` is advisory.** `error-on-warning = false`, and the noisy `ty` rules are set to `warn`, so it exits 0 while reporting diagnostics. Read its output; a green exit is not a clean type check.
+- **Ruff selects only `E`, `F`, `I001`, `W`.** Annotation, naming and docstring rules are enforced by nobody, so what `CONTRIBUTING.md` states about typing and naming is convention a reviewer checks, not a gate. One convention it does not state: no inline comments and no docstrings — names carry the meaning, and a comment is a second source of truth nothing verifies.
+
+## Release
+
+The version lives in `[project] version` of `pyproject.toml`, and that field is the only one the release reads.
+
+Publishing is manual and never happens on merge. Run the `PyPI Release` workflow with a semantic version; it rewrites that field, pushes the bump directly to `main`, cuts the GitHub release, builds, publishes to PyPI, and opens a pull request from `gh/release-<version>`.
 
 ## Dependencies
 
-All dependencies pinned to exact versions. Renovate handles updates automatically:
-
-- Minor/patch updates: Auto-merged after 7 days
-- Major updates (dev deps): Auto-merged after 14 days
-- Security updates: Immediate
-
-## Key Files
-
-| File                                           | Purpose                                     |
-| ---------------------------------------------- | ------------------------------------------- |
-| `pyproject.toml`                               | Project config, dependencies, tool settings |
-| `.pre-commit-config.yaml`                      | Pre-commit hooks configuration              |
-| `Makefile`                                     | Development commands                        |
-| `renovate.json`                                | Dependency update automation                |
-| `.github/workflows/continuous-integration.yml` | CI workflow                                 |
-| `.github/workflows/pypi-release.yml`           | PyPI release workflow                       |
+Every dependency is pinned to an exact version. Renovate auto-merges minor and patch updates after 7 days, major updates to dev dependencies after 14, and security updates immediately.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON_FILES = $(shell find src examples -iname "*.py" -not -path "**/__pycache__/**")
+PYTHON_FILES = $(shell find src tests examples -iname "*.py" -not -path "**/__pycache__/**")
 
 .PHONY: setup setup-hard format format-fix lint lint-fix types test test-coverage uv-lock uv-update marimo help
 


### PR DESCRIPTION
Part of an estate-wide agentic-layer conformance pass. `sirtuin` and `topologyx` are one template, so the same pass runs in both; nothing here depends on another repository's branch landing first.

## CLAUDE.md

Rewritten around what a contributor or a session actually needs and cannot derive by reading the tree.

Removed: the project-structure tree and the key-files table, both restatements of `ls` that drift; the prerequisites and quick-start blocks, which `README.md` already carries. The tree also described `main.py` as the CLI entry point, which it is not — the file is empty.

Added: that each subpackage `__init__.py` holds the implementation rather than re-exports; the public API surface and what breaks semver; that Gudhi ships no type stubs, which is why the `# type: ignore` markers and `SimplexTreeProtocol` exist; that importing `topologyx.channels` pulls in Keras while the other two subpackages do not; the dimensional ceiling on the non-alpha `Filtration` path; the manual PyPI release flow and the fact that `[project] version` is the only field it reads; what the pre-commit gate enforces.

Two gates are documented as weaker than they look. `make types` exits 0 while reporting diagnostics, because `error-on-warning = false` and the noisy `ty` rules are set to `warn` — a green exit is not a clean type check. Ruff selects only `E`, `F`, `I001`, `W`, so the typing and naming conventions in `CONTRIBUTING.md` are reviewer conventions rather than gates.

## CI

The test suite existed, passed, and nothing ran it. `make test` added to the continuous-integration workflow, matching `sirtuin`. Thirty-two tests, green.

## Makefile

`PYTHON_FILES` covered `src` and `examples` but not `tests`, so `make lint` and `make format` skipped the test suite; `tests` added, and both targets stay clean with it. `.coverage` added to `.gitignore`, since `make test-coverage` leaves one behind.

## Verified

`make format`, `make lint`, `make types` and `make test` all pass locally on this branch.

## Findings not addressed here

- `pyproject.toml` declares a `topologyx` console script pointing at `topologyx.main:cli`, but `src/topologyx/main.py` is empty, so the command installed by the published package fails. Documented in CLAUDE.md. Fixing it means either implementing a CLI or dropping `[project.scripts]`, and that is a release-shaped decision.
- `scipy.stats.gaussian_kde` is imported by `clustering/` but SciPy is not a declared dependency; it arrives transitively through scikit-learn. Documented, not fixed.
- `tqdm` and `plotly` are declared runtime dependencies with no import anywhere in the repository.
- `[tool.ty.src]` includes only `src/topologyx`, so the test suite is not type-checked. Adding `tests` raises the diagnostic count from 13 to 16 without failing anything, so it is noise rather than a fix; left alone.