### PR TITLE
chore(deps): align the renovate config with the verified fleet shape

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,6 +11,9 @@ jobs:
   workflow:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      # renovate: datasource=npm depName=renovate
+      RENOVATE_VERSION: '44.65.5'
 
     steps:
       - name: Checkout Codebase
@@ -36,3 +39,6 @@ jobs:
 
       - name: Run Type Check
         run: make types
+
+      - name: Validate Renovate Config
+        run: npx --yes --package "renovate@${RENOVATE_VERSION}" renovate-config-validator --strict

--- a/renovate.json
+++ b/renovate.json
@@ -9,14 +9,26 @@
   "schedule": ["before 6am on Monday"],
   "timezone": "Europe/Paris",
   "vulnerabilityAlerts": {
-    "enabled": true,
-    "labels": ["security", "urgent"],
-    "assignees": ["merylldindin"],
-    "minimumReleaseAge": "0 days"
+    "enabled": false
   },
-  "osvVulnerabilityAlerts": true,
   "rangeStrategy": "pin",
   "ignoreDeps": ["python"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "semanticCommitType": "build",
+    "semanticCommitScope": "deps"
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Version literals pinned in workflow env values, which no manifest covers",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.yml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\w+_VERSION:\\s*['\"]?(?<currentValue>[^'\"\\s]+)['\"]?"
+      ]
+    }
+  ],
   "packageRules": [
     {
       "description": "Ignore Python version updates",
@@ -33,7 +45,6 @@
       "matchUpdateTypes": [
         "bump",
         "digest",
-        "lockFileMaintenance",
         "minor",
         "patch",
         "pin",
@@ -54,6 +65,11 @@
       "semanticCommitType": "build",
       "semanticCommitScope": "deps",
       "matchPackageNames": ["!python"]
+    },
+    {
+      "description": "The python-version datasource carries no category, so the matchCategories rules never reach it; this must stay last because later rules win",
+      "enabled": false,
+      "matchDatasources": ["python-version"]
     }
   ]
 }


### PR DESCRIPTION
lockFileMaintenance was listed as a matchUpdateTypes value but never enabled, and Renovate disables that lane by default, so it has never run here and every transitive refresh has been done by hand. It is now enabled at the top level, where it keeps its own weekly default schedule, and the inert matchUpdateTypes entries are gone.

Renovate was also raising security PRs alongside Dependabot, which already owns security here: alerts and automated security fixes are both on and there is no dependabot.yml, so the two lanes only duplicated each other. Disabling vulnerabilityAlerts has to be explicit, because omitting the key leaves it enabled, and osvVulnerabilityAlerts goes with it.

The python-version datasource carries no category, so the matchCategories rules never reached it. It now has an explicit disable, placed last because later rules win.

Nothing validated the config itself. renovate-config-validator now runs as the last step of the existing CI job behind a pinned RENOVATE_VERSION, with a customManager so the pin does not rot.