### PR TITLE
chore(deps): let renovate automerge the custom manager version literals

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -70,6 +70,33 @@
       "description": "The python-version datasource carries no category, so the matchCategories rules never reach it; this must stay last because later rules win",
       "enabled": false,
       "matchDatasources": ["python-version"]
+    },
+    {
+      "description": "A dependency found by a regex customManager belongs to the custom.regex manager and carries no category, so no matchCategories or matchManagers rule above can reach it however its datasourceTemplate reads. Without this rule those updates default to automerge false and wait for a human forever. pre-commit is listed for the same reason: its category is ci, not python.",
+      "automerge": true,
+      "groupName": "ci tooling",
+      "matchManagers": ["custom.regex", "pre-commit"],
+      "matchUpdateTypes": [
+        "bump",
+        "digest",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "rollback"
+      ],
+      "minimumReleaseAge": "7 days",
+      "semanticCommitType": "build",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "automerge": false,
+      "groupName": "ci tooling breaking changes",
+      "matchManagers": ["custom.regex", "pre-commit"],
+      "matchUpdateTypes": ["major", "replacement"],
+      "minimumReleaseAge": "21 days",
+      "semanticCommitType": "build",
+      "semanticCommitScope": "deps"
     }
   ]
 }


### PR DESCRIPTION
A dependency found by a regex customManager belongs to the custom.regex manager and carries no category, so none of the matchCategories or matchManagers rules in this config can reach it, whatever its datasourceTemplate reads. With nothing matching, those updates fall back to the automerge default of false.

That bites here directly: the pinned RENOVATE_VERSION this repository now validates its renovate config against is governed only by a customManager, so its bumps would open PRs that never merge and wait on a human indefinitely.

Two rules close it, matching custom.regex and pre-commit together since pre-commit's category is ci rather than python. Non-major updates automerge after seven days; majors and replacements are held for review at twenty-one.

Validated with renovate-config-validator --strict. The change is a pure addition: every existing rule keeps its position and content.